### PR TITLE
update nokogiri version to 1.10.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,7 +106,7 @@ GEM
     msgpack (1.2.6)
     netrc (0.11.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     parallel (1.14.0)
     parser (2.6.0.0)
@@ -242,4 +242,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
Due to vulnerability issues nokogiri needs to be updated to 1.10.4 